### PR TITLE
Update ruamel.yaml dependency to prevent conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'Programming Language :: Python :: 3.10'
     ],
     install_requires=[
-        'ruamel.yaml>=0.15.71,<0.17',
+        'ruamel.yaml>=0.15.71',
         'typing_extensions'
     ]
 )


### PR DESCRIPTION
@LourensVeen @sdruskat  Update the ruamel.yaml dependency from `>=0.15.71,<0.17` to `>=0.15.71`. 

Because yatiml works well with ruamel.yaml >0.17 (the tests pass on python 3.9), and some packages now requires ruaml.yaml>0.17, which creates conflicts when used in the same project as yatiml (e.g. https://github.com/iterative/dvc). And makes it really hard to use yatiml

There is nothing to do apart from removing `<0.17` from the `setup.py` requirements and checking the tests pass :) 