### PR TITLE
Fix Union in Python 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Check out the source code

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 files = yatiml/**/*.py, tests/**/*.py
 
-python_version = 3.9
+python_version = 3.10
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
 warn_return_any = True

--- a/tests/test_builtin_types.py
+++ b/tests/test_builtin_types.py
@@ -230,6 +230,16 @@ def test_union_mismatch() -> None:
         load('2.71')
 
 
+def test_new_union() -> None:
+    load = yatiml.load_function(str | int)          # type: ignore
+    data = load('10')
+    assert isinstance(data, int)
+    assert data == 10
+    data = load('test')
+    assert isinstance(data, str)
+    assert data == 'test'
+
+
 def test_optional() -> None:
     load = yatiml.load_function(Optional[str])      # type: ignore
     data = load('test')

--- a/yatiml/util.py
+++ b/yatiml/util.py
@@ -3,6 +3,7 @@ from collections import abc, UserString
 from difflib import get_close_matches
 from datetime import date
 from inspect import isabstract, isclass
+import types
 import typing
 from typing import (
         Any, cast, Dict, Iterable, Mapping, MutableMapping, MutableSequence,
@@ -151,8 +152,8 @@ def is_generic_union(type_: Type) -> bool:
     Returns:
         True iff it's a Union[...something...].
     """
-    if typing.get_origin(type_) is typing.Union:
-        # 3.8 and up
+    if typing.get_origin(type_) in (typing.Union, types.UnionType):
+        # 3.8 and up, required from 3.14
         return True
 
     if hasattr(typing, '_GenericAlias'):

--- a/yatiml/util.py
+++ b/yatiml/util.py
@@ -151,6 +151,10 @@ def is_generic_union(type_: Type) -> bool:
     Returns:
         True iff it's a Union[...something...].
     """
+    if typing.get_origin(type_) is typing.Union:
+        # 3.8 and up
+        return True
+
     if hasattr(typing, '_GenericAlias'):
         # 3.7
         return (isinstance(type_, typing._GenericAlias) and     # type: ignore


### PR DESCRIPTION
This adds Python 3.14 support (and removes 3.9), fixes `Union[int, str]` there, and adds support for `int | str` in general.

Addresses #58.